### PR TITLE
Add new routing for homepage, now '/'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "5e-spellbook",
-  "homepage": "http://Shawntru.github.io/5e-Spellbook",
+  "homepage": "http://Shawntru.github.io/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -12,7 +12,8 @@ const App = () => {
       <Nav />
       <div className="App">
         <Switch>
-          <Route exact path="/5e-spellbook" component={Homepage} />
+          <Route exact path="/" component={Homepage} />
+          {/* <Route exact path="/5e-spellbook" component={Homepage} /> */}
           <Route exact path="/spells/:pcClass" component={SpellSearch} />
           <Route exact path="/spellbook" component={SpellBook} />
         </Switch>

--- a/src/App/App.test.js
+++ b/src/App/App.test.js
@@ -26,7 +26,7 @@ describe('App', () => {
 
   it('should handle path to main page', async () => {
     const history = createMemoryHistory();
-    history.push('/5e-spellbook');
+    history.push('/');
     render(
       <Router history={history}>
         <App />
@@ -72,7 +72,7 @@ describe('App', () => {
 describe('Homepage navigation interaction', () => {
   it('should navigate to the spell search view when a class is clicked on', async () => {
     const history = createMemoryHistory();
-    history.push('/5e-spellbook');
+    history.push('/');
 
     render(
       <Router history={history}>
@@ -89,7 +89,7 @@ describe('Homepage navigation interaction', () => {
 
   it('should navigate to the spell book view when Go To Spellbook is clicked on', async () => {
     const history = createMemoryHistory();
-    history.push('/5e-spellbook');
+    history.push('/');
 
     render(
       <Router history={history}>
@@ -108,7 +108,7 @@ describe('Homepage navigation interaction', () => {
 describe('NavBar integration testing', () => {
   it('should navigate home when Slecet a Class is clicked on', async () => {
     const history = createMemoryHistory();
-    history.push('/5e-spellbook');
+    history.push('/');
 
     render(
       <Router history={history}>
@@ -126,7 +126,7 @@ describe('NavBar integration testing', () => {
 
   it('should navigate to the spell book view when Your Spell Book is clicked on', async () => {
     const history = createMemoryHistory();
-    history.push('/5e-spellbook');
+    history.push('/');
 
     render(
       <Router history={history}>

--- a/src/Nav/Nav.js
+++ b/src/Nav/Nav.js
@@ -7,7 +7,7 @@ const Nav = () => {
     <nav className="nav-bar-wrapper" data-testid="nav-bar-test">
       <div className="nav-underline-wrapper">
         <div className="gold-left"></div>
-        <Link to={'/5e-spellbook'} className="nav-link">
+        <Link to={'/'} className="nav-link">
           <h3>Select a Class</h3>
         </Link>
         <h2 className="site-title">The Dusty Tome</h2>


### PR DESCRIPTION
## What is the change?
New routing for homepage in router
## What does it fix?
Page load now correctly shows spell classes to choose from
## Is this a fix or a feature? 
Fix
## How should this be tested?
`npm test /src`
